### PR TITLE
[FEAT] 멤버 온라인 상태 표시

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import { ChatMessageService } from "./chat/service/ChatMessageService";
 import { PrismaChatRoomRepository } from "./chat/repository/PrismaChatRoomRepository";
 import { PrismaMemberRepository } from "./member/repository/PrismaMemberRepository";
 import { chatMessageRouter } from "./chat/web/controller/chatMessage.router";
+import { PresenceService } from "./chat/service/PresenceService";
 
 // 1. Express 앱 생성
 const app = express();
@@ -27,6 +28,7 @@ const io = new Server(httpServer, {
   },
 });
 
+const presenceService = new PresenceService();
 const ChatMessageRepository = new PrismaChatMessageRepository(prisma);
 const chatRoomRepository = new PrismaChatRoomRepository(prisma);
 const memberRepository = new PrismaMemberRepository(prisma);
@@ -41,7 +43,7 @@ instrument(io, {
   mode: "development",
 });
 
-const chatGateway = new ChatGateway(io, chatMessageService, chatRoomRepository);
+const chatGateway = new ChatGateway(io, chatMessageService, chatRoomRepository, presenceService);
 chatGateway.initialize();
 
 app.use(

--- a/src/chat/ChatGateway.ts
+++ b/src/chat/ChatGateway.ts
@@ -10,22 +10,28 @@ import {
 import { ChatMessageService } from "./service/ChatMessageService";
 import { IChatRoomRepository } from "./domain/IChatRoomRepository";
 import { JoinRoomDto } from "./web/dto/ChatRoom.dto";
+import { MemberId } from "@/member/domain/MemberId";
+import { Member } from "@/member/domain/Member";
+import { PresenceService } from "./service/PresenceService";
 
 //TODO: 파일 네이밍 변경
 export class ChatGateway {
   private io: Server;
   private chatMessageService: ChatMessageService;
   private chatRoomRepository: IChatRoomRepository;
-  private userSocketMap = new Map<string, string>();
+  private presenceService: PresenceService;
 
   constructor(
     io: Server,
     chatMessageService: ChatMessageService,
-    chatRoomRepository: IChatRoomRepository
+    chatRoomRepository: IChatRoomRepository,
+    presenceService: PresenceService
   ) {
     this.io = io;
     this.chatMessageService = chatMessageService;
     this.chatRoomRepository = chatRoomRepository;
+    this.presenceService = presenceService;
+
   }
 
   // 게이트웨이 초기 설정
@@ -40,7 +46,7 @@ export class ChatGateway {
     if (!token) return next(new Error("액세스 토큰이 없습니다."));
     try {
       const decoded = validateAccessToken(token);
-      socket.data = { memberId: decoded.memberId };
+      socket.data = { memberId: MemberId(decoded.memberId) };
       next();
     } catch (error) {
       return next(new Error("유효하지 않은 액세스 토큰"));
@@ -51,7 +57,7 @@ export class ChatGateway {
   private handleConnection = (socket: Socket) => {
     const memberId = socket.data.memberId;
     console.log(`✅ User connected: ${socket.id}, Member ID: ${memberId}`);
-    this.userSocketMap.set(memberId, socket.id);
+    this.presenceService.addUser(memberId, socket.id)
 
     socket.on("sendMessage", (dto: SendMessageDto) =>
       this.handleSendMessage(socket, dto)
@@ -116,7 +122,7 @@ export class ChatGateway {
     if (memberId) {
       console.log(`❌ User disconnected: ${socket.id}, Member ID: ${memberId}`);
       // 👇 2. memberId가 있을 때만 map에서 삭제합니다.
-      this.userSocketMap.delete(memberId);
+      this.presenceService.removeUser(memberId)
     } else {
       // memberId가 없는 비정상적인 연결 종료 (예: 인증 실패 후)
       console.log(`❌ Socket disconnected: ${socket.id}`);

--- a/src/chat/ChatGateway.ts
+++ b/src/chat/ChatGateway.ts
@@ -57,7 +57,7 @@ export class ChatGateway {
   private handleConnection = (socket: Socket) => {
     const memberId = socket.data.memberId;
     console.log(`✅ User connected: ${socket.id}, Member ID: ${memberId}`);
-    this.presenceService.addUser(memberId, socket.id)
+    this.presenceService.addUser(memberId, socket.id);
 
     socket.on("sendMessage", (dto: SendMessageDto) =>
       this.handleSendMessage(socket, dto)
@@ -122,7 +122,7 @@ export class ChatGateway {
     if (memberId) {
       console.log(`❌ User disconnected: ${socket.id}, Member ID: ${memberId}`);
       // 👇 2. memberId가 있을 때만 map에서 삭제합니다.
-      this.presenceService.removeUser(memberId)
+      this.presenceService.removeUser(memberId);
     } else {
       // memberId가 없는 비정상적인 연결 종료 (예: 인증 실패 후)
       console.log(`❌ Socket disconnected: ${socket.id}`);

--- a/src/chat/service/PresenceService.ts
+++ b/src/chat/service/PresenceService.ts
@@ -1,0 +1,19 @@
+import { MemberId } from "@/member/domain/MemberId";
+
+export class PresenceService {
+  private onlineUsers = new Map<MemberId, string>();
+
+  public addUser(memberId: MemberId, socketId: string): void {
+    this.onlineUsers.set(memberId, socketId);
+    console.log("Online Users: ", this.onlineUsers.keys());
+  }
+
+  public removeUser(memberId: MemberId): void {
+    this.onlineUsers.delete(memberId);
+    console.log("Online Users:", this.onlineUsers.keys());
+  }
+
+  public isUserOnline(memberId: MemberId): boolean {
+    return this.onlineUsers.has(memberId);
+  }
+}

--- a/src/member/service/MemberService.ts
+++ b/src/member/service/MemberService.ts
@@ -64,8 +64,8 @@ export class MemberService {
 
     const memberDto = MemberDto.fromDomain(member);
 
-    memberDto.isOnline = this.presenceService.isUserOnline(memberId)
+    memberDto.isOnline = this.presenceService.isUserOnline(memberId);
 
-    return memberDto
+    return memberDto;
   }
 }

--- a/src/member/service/MemberService.ts
+++ b/src/member/service/MemberService.ts
@@ -3,9 +3,13 @@ import { Member } from "../domain/Member";
 import { MemberId } from "../domain/MemberId";
 import * as bcrypt from "bcrypt";
 import { MemberDto, MemberSignInDTO, MemberSignUpDto } from "@/member/web/dto";
+import { PresenceService } from "@/chat/service/PresenceService";
 
 export class MemberService {
-  constructor(private readonly memberRepository: IMemberRepository) {}
+  constructor(
+    private readonly memberRepository: IMemberRepository,
+    private readonly presenceService: PresenceService
+  ) {}
 
   //회원가입
   public async signup(props: MemberSignUpDto): Promise<MemberDto> {
@@ -58,6 +62,10 @@ export class MemberService {
       throw new Error("Member not found");
     }
 
-    return MemberDto.fromDomain(member);
+    const memberDto = MemberDto.fromDomain(member);
+
+    memberDto.isOnline = this.presenceService.isUserOnline(memberId)
+
+    return memberDto
   }
 }

--- a/src/member/web/dto.ts
+++ b/src/member/web/dto.ts
@@ -6,6 +6,7 @@ export class MemberDto {
   readonly id: MemberId;
   readonly loginId: string;
   readonly nickname: string;
+  isOnline: boolean = false; 
 
   private constructor(props: {
     id: MemberId;


### PR DESCRIPTION
<!--  .github/PULL_REQUEST_TEMPLATE.md  -->

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. leerura -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #17 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
온라인 사용자 저장하는 presenceService class 생성했습니다.
memberDto에서 isOnline 필드 추가하여 멤버 조회시 온라인 여부도 추가했습니다.

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?